### PR TITLE
Update repository info

### DIFF
--- a/doc/source/cobsr-intro.rst
+++ b/doc/source/cobsr-intro.rst
@@ -250,7 +250,7 @@ References
             | Universidade do Porto / INESC Porto
             | IEEE ICC 2007
 
-.. [C3]     | `C Implementation of COBS and COBS/R <http://bitbucket.org/cmcqueen1975/cobs-c>`_
+.. [C3]     | `C Implementation of COBS and COBS/R <https://github.com/cmcqueen/cobs-c>`_
             | Craig McQueen
 
 .. [C4]     | :ref:`Python Implementation of COBS and COBS/R <index>`

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -64,7 +64,7 @@ References
                 | Stuart Cheshire and Mary Baker, Stanford University
                 | November 1997
 
-.. [Cimpl]      | `C Implementation of COBS and COBS/R <http://bitbucket.org/cmcqueen1975/cobs-c>`_
+.. [Cimpl]      | `C Implementation of COBS and COBS/R <https://github.com/cmcqueen/cobs-c>`_
                 | Craig McQueen
 
 
@@ -126,7 +126,7 @@ Download
 
 Source code and binaries can be downloaded from the `Python package index <http://pypi.python.org/pypi/cobs>`_.
 
-The Mercurial source code repository for development is on `Bitbucket <http://bitbucket.org/cmcqueen1975/cobs-python>`_.
+The Git source code repository for development is on `GitHub <https://github.com/cmcqueen/cobs-python>`_.
 
 
 ------------

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup_dict = dict(
     description='Consistent Overhead Byte Stuffing (COBS)',
     author='Craig McQueen',
     author_email='python@craig.mcqueen.id.au',
-    url='http://bitbucket.org/cmcqueen1975/cobs-python/',
+    url='https://github.com/cmcqueen/cobs-python/',
     packages=[ 'cobs', 'cobs.cobs', 'cobs.cobsr', 'cobs._version', ],
     package_dir={
         'cobs' : base_dir + '/cobs',


### PR DESCRIPTION
Suggest updating the repository info such that https://pypi.org/project/cobs and docs point directly to the current source location.