### PR TITLE
add two new functions

### DIFF
--- a/python3/cobs/cobs/__init__.py
+++ b/python3/cobs/cobs/__init__.py
@@ -27,3 +27,14 @@ DecodeError.__module__ = 'cobs.cobs'
 
 from .._version import *
 
+
+def encoding_overhead(source_len: int) -> int:
+    """Calculates the maximum overhead when encoding a message with the given length.
+    The overhead is a maximum of [n/254] bytes (one in 254 bytes) rounded up."""
+    return (source_len + 254 - 1) // 254
+
+
+def max_encoded_length(source_len: int) -> int:
+    """Calculates how maximum possible size of an encoded message given the length of the
+    source message."""
+    return source_len + encoding_overhead(source_len)

--- a/python3/cobs/cobs/__init__.py
+++ b/python3/cobs/cobs/__init__.py
@@ -28,13 +28,13 @@ DecodeError.__module__ = 'cobs.cobs'
 from .._version import *
 
 
-def encoding_overhead(source_len: int) -> int:
+def encoding_overhead(source_len):
     """Calculates the maximum overhead when encoding a message with the given length.
     The overhead is a maximum of [n/254] bytes (one in 254 bytes) rounded up."""
     return (source_len + 254 - 1) // 254
 
 
-def max_encoded_length(source_len: int) -> int:
+def max_encoded_length(source_len):
     """Calculates how maximum possible size of an encoded message given the length of the
     source message."""
     return source_len + encoding_overhead(source_len)

--- a/python3/cobs/cobs/__init__.py
+++ b/python3/cobs/cobs/__init__.py
@@ -26,15 +26,3 @@ except ImportError:
 DecodeError.__module__ = 'cobs.cobs'
 
 from .._version import *
-
-
-def encoding_overhead(source_len):
-    """Calculates the maximum overhead when encoding a message with the given length.
-    The overhead is a maximum of [n/254] bytes (one in 254 bytes) rounded up."""
-    return (source_len + 254 - 1) // 254
-
-
-def max_encoded_length(source_len):
-    """Calculates how maximum possible size of an encoded message given the length of the
-    source message."""
-    return source_len + encoding_overhead(source_len)

--- a/python3/cobs/cobs/_cobs_py.py
+++ b/python3/cobs/cobs/_cobs_py.py
@@ -88,3 +88,17 @@ def decode(in_bytes):
             else:
                 break
     return bytes(out_bytes)
+
+
+def encoding_overhead(source_len):
+    """Calculates the maximum overhead when encoding a message with the given length.
+    The overhead is a maximum of [n/254] bytes (one in 254 bytes) rounded up."""
+    if source_len == 0:
+        return 1
+    return (source_len + 253) // 254
+
+
+def max_encoded_length(source_len):
+    """Calculates how maximum possible size of an encoded message given the length of the
+    source message."""
+    return source_len + encoding_overhead(source_len)

--- a/python3/cobs/cobs/test.py
+++ b/python3/cobs/cobs/test.py
@@ -13,7 +13,6 @@ import unittest
 from .. import cobs as cobs
 #from ..cobs import _cobs_py as cobs
 
-
 def infinite_non_zero_generator():
     while True:
         for i in range(1,50):
@@ -189,6 +188,25 @@ class InputTypesTest(unittest.TestCase):
             array_encoded_string = array(typecode, [6, 49, 50, 51, 52, 53 ])
             with self.assertRaises(BufferError):
                 cobs.decode(array_encoded_string)
+
+
+class UtilTests(unittest.TestCase):
+
+    def test_encoded_len_calc(self):
+        self.assertEqual(cobs.encoding_overhead(5), 1)
+        self.assertEqual(cobs.max_encoded_length(5), 6)
+
+    def test_encoded_len_calc_empty_packet(self):
+        self.assertEqual(cobs.encoding_overhead(0), 0)
+        self.assertEqual(cobs.max_encoded_length(0), 0)
+
+    def test_encoded_len_calc_still_one_byte_overhead(self):
+        self.assertEqual(cobs.encoding_overhead(254), 1)
+        self.assertEqual(cobs.max_encoded_length(254), 255)
+
+    def test_encoded_len_calc_two_byte_overhead(self):
+        self.assertEqual(cobs.encoding_overhead(255), 2)
+        self.assertEqual(cobs.max_encoded_length(255), 257)
 
 
 def runtests():

--- a/python3/cobs/cobs/test.py
+++ b/python3/cobs/cobs/test.py
@@ -197,8 +197,8 @@ class UtilTests(unittest.TestCase):
         self.assertEqual(cobs.max_encoded_length(5), 6)
 
     def test_encoded_len_calc_empty_packet(self):
-        self.assertEqual(cobs.encoding_overhead(0), 0)
-        self.assertEqual(cobs.max_encoded_length(0), 0)
+        self.assertEqual(cobs.encoding_overhead(0), 1)
+        self.assertEqual(cobs.max_encoded_length(0), 1)
 
     def test_encoded_len_calc_still_one_byte_overhead(self):
         self.assertEqual(cobs.encoding_overhead(254), 1)

--- a/python3/cobs/cobsr/_cobsr_py.py
+++ b/python3/cobs/cobsr/_cobsr_py.py
@@ -96,3 +96,17 @@ def decode(in_bytes):
             else:
                 break
     return bytes(out_bytes)
+
+
+def encoding_overhead(source_len):
+    """Calculates the maximum overhead when encoding a message with the given length.
+    The overhead is a maximum of [n/254] bytes (one in 254 bytes) rounded up."""
+    if source_len == 0:
+        return 1
+    return (source_len + 253) // 254
+
+
+def max_encoded_length(source_len):
+    """Calculates how maximum possible size of an encoded message given the length of the
+    source message."""
+    return source_len + encoding_overhead(source_len)

--- a/python3/cobs/cobsr/test.py
+++ b/python3/cobs/cobsr/test.py
@@ -223,6 +223,25 @@ class InputTypesTest(unittest.TestCase):
                 cobsr.decode(array_encoded_string)
 
 
+class UtilTests(unittest.TestCase):
+
+    def test_encoded_len_calc(self):
+        self.assertEqual(cobs.encoding_overhead(5), 1)
+        self.assertEqual(cobs.max_encoded_length(5), 6)
+
+    def test_encoded_len_calc_empty_packet(self):
+        self.assertEqual(cobs.encoding_overhead(0), 1)
+        self.assertEqual(cobs.max_encoded_length(0), 1)
+
+    def test_encoded_len_calc_still_one_byte_overhead(self):
+        self.assertEqual(cobs.encoding_overhead(254), 1)
+        self.assertEqual(cobs.max_encoded_length(254), 255)
+
+    def test_encoded_len_calc_two_byte_overhead(self):
+        self.assertEqual(cobs.encoding_overhead(255), 2)
+        self.assertEqual(cobs.max_encoded_length(255), 257)
+
+
 def runtests():
     unittest.main()
 

--- a/python3/cobs/cobsr/test.py
+++ b/python3/cobs/cobsr/test.py
@@ -226,20 +226,20 @@ class InputTypesTest(unittest.TestCase):
 class UtilTests(unittest.TestCase):
 
     def test_encoded_len_calc(self):
-        self.assertEqual(cobs.encoding_overhead(5), 1)
-        self.assertEqual(cobs.max_encoded_length(5), 6)
+        self.assertEqual(cobsr.encoding_overhead(5), 1)
+        self.assertEqual(cobsr.max_encoded_length(5), 6)
 
     def test_encoded_len_calc_empty_packet(self):
-        self.assertEqual(cobs.encoding_overhead(0), 1)
-        self.assertEqual(cobs.max_encoded_length(0), 1)
+        self.assertEqual(cobsr.encoding_overhead(0), 1)
+        self.assertEqual(cobsr.max_encoded_length(0), 1)
 
     def test_encoded_len_calc_still_one_byte_overhead(self):
-        self.assertEqual(cobs.encoding_overhead(254), 1)
-        self.assertEqual(cobs.max_encoded_length(254), 255)
+        self.assertEqual(cobsr.encoding_overhead(254), 1)
+        self.assertEqual(cobsr.max_encoded_length(254), 255)
 
     def test_encoded_len_calc_two_byte_overhead(self):
-        self.assertEqual(cobs.encoding_overhead(255), 2)
-        self.assertEqual(cobs.max_encoded_length(255), 257)
+        self.assertEqual(cobsr.encoding_overhead(255), 2)
+        self.assertEqual(cobsr.max_encoded_length(255), 257)
 
 
 def runtests():


### PR DESCRIPTION
Hi.

Thanks for providing this package!
I added some minor utility functions to calculate the deterministic encoding overhead.

- `encoding_overhead` for a given source length
- `max_encoded_length` for a given source length
- Unittests for both functions

I had to re-install the package to make the unittests run.. Is this intended?