### PR TITLE
Don't build C source if running on PYPY

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import os
 import sys
 
 from setuptools import setup, Extension
@@ -12,11 +13,13 @@ setup_dict = dict(
     package_dir={
         'cobs' : 'src/cobs',
     },
-    ext_modules=[
-        Extension('cobs.cobs._cobs_ext', [ 'src/ext/_cobs_ext.c', ]),
-        Extension('cobs.cobsr._cobsr_ext', [ 'src/ext/_cobsr_ext.c', ]),
-    ],
 )
+
+if not hasattr(sys, "pypy_version_info") and os.environ.get("COBS_PUREPYTHON"):
+    setup_dict['ext_modules'] = [
+                                    Extension('cobs.cobs._cobs_ext',    [ 'src/ext/_cobs_ext.c',  ]),
+                                    Extension('cobs.cobsr._cobsr_ext',  [ 'src/ext/_cobsr_ext.c', ])
+                                ]
 
 try:
     setup(**setup_dict)


### PR DESCRIPTION
Avoid building C optimised version if running on PYPY and use the plain python implementation

1.  pypy have a penalty cost at the python to C interface
2. I found this memory leak: https://github.com/pypy/pypy/issues/5100

As implementation I took inspiration from msgpack https://github.com/msgpack/msgpack-python/blob/main/setup.py

Alternative is to use `import cobs.cobs._cobs_py as cobs` instead of `from cobs import cobs` but this move the burden to the userspace and it is pretty ugly

Thanks,
Luca