### PR TITLE
Fix packaging name/version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ if sys.version_info[0] == 2:
     raise Exception('Python 2.x is no longer supported')
 
 setup_dict = dict(
+    name="cobs",
+    version="1.2.1",
     packages=[ 'cobs', 'cobs.cobs', 'cobs.cobsr', 'cobs._version', ],
     package_dir={
         'cobs' : 'src/cobs',


### PR DESCRIPTION
Even though name/version exist in pyproject.toml, I had to add them to setup.py for python3.10 to be able to generate correct egg/wheel packages locally and install as "cobs" not as "UNKNOWN".

This is a problem for me because I use a weak/E-core laptop (Pentium N6000) and it cannot saturate USB HS when decoding via the fallback bytecode implementation, it needs the native C library. I imagine SBC and embedded Linux boards are in a similar situation (armhf, aarch64 etc.)
PyPI wheel of 1.2.0 for Linux is `none-any.whl` meaning no native extensions.

<details>
<summary>Install log for current `main`</summary>

```sh
altracer@HP-15s-fq3025ur ~/g/c/cobs-python (main)> python3 setup.py bdist_wheel
running bdist_wheel
running build
running build_py
creating build
creating build/lib.linux-x86_64-3.10
creating build/lib.linux-x86_64-3.10/cobs
copying src/cobs/__init__.py -> build/lib.linux-x86_64-3.10/cobs
creating build/lib.linux-x86_64-3.10/cobs/cobs
copying src/cobs/cobs/_cobs_py.py -> build/lib.linux-x86_64-3.10/cobs/cobs
copying src/cobs/cobs/__init__.py -> build/lib.linux-x86_64-3.10/cobs/cobs
copying src/cobs/cobs/test.py -> build/lib.linux-x86_64-3.10/cobs/cobs
creating build/lib.linux-x86_64-3.10/cobs/cobsr
copying src/cobs/cobsr/__init__.py -> build/lib.linux-x86_64-3.10/cobs/cobsr
copying src/cobs/cobsr/_cobsr_py.py -> build/lib.linux-x86_64-3.10/cobs/cobsr
copying src/cobs/cobsr/test.py -> build/lib.linux-x86_64-3.10/cobs/cobsr
creating build/lib.linux-x86_64-3.10/cobs/_version
copying src/cobs/_version/__init__.py -> build/lib.linux-x86_64-3.10/cobs/_version
running build_ext
building 'cobs.cobs._cobs_ext' extension
creating build/temp.linux-x86_64-3.10
creating build/temp.linux-x86_64-3.10/src
creating build/temp.linux-x86_64-3.10/src/ext
x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_F
ORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.10 -c src/ext/_cobs_ext.c -o build/temp.linux-x86_64-3.10/src/ext/_cobs_ext.o
x86_64-linux-gnu-gcc -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -fwrapv -O2 -Wl,-Bsymbolic-functions -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 bui
ld/temp.linux-x86_64-3.10/src/ext/_cobs_ext.o -o build/lib.linux-x86_64-3.10/cobs/cobs/_cobs_ext.cpython-310-x86_64-linux-gnu.so
building 'cobs.cobsr._cobsr_ext' extension
x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_F
ORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.10 -c src/ext/_cobsr_ext.c -o build/temp.linux-x86_64-3.10/src/ext/_cobsr_ext.o
x86_64-linux-gnu-gcc -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -fwrapv -O2 -Wl,-Bsymbolic-functions -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 bui
ld/temp.linux-x86_64-3.10/src/ext/_cobsr_ext.o -o build/lib.linux-x86_64-3.10/cobs/cobsr/_cobsr_ext.cpython-310-x86_64-linux-gnu.so
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/cobs
creating build/bdist.linux-x86_64/wheel/cobs/cobs
copying build/lib.linux-x86_64-3.10/cobs/cobs/_cobs_py.py -> build/bdist.linux-x86_64/wheel/cobs/cobs
copying build/lib.linux-x86_64-3.10/cobs/cobs/__init__.py -> build/bdist.linux-x86_64/wheel/cobs/cobs
copying build/lib.linux-x86_64-3.10/cobs/cobs/_cobs_ext.cpython-310-x86_64-linux-gnu.so -> build/bdist.linux-x86_64/wheel/cobs/cobs
copying build/lib.linux-x86_64-3.10/cobs/cobs/test.py -> build/bdist.linux-x86_64/wheel/cobs/cobs
creating build/bdist.linux-x86_64/wheel/cobs/_version
copying build/lib.linux-x86_64-3.10/cobs/_version/__init__.py -> build/bdist.linux-x86_64/wheel/cobs/_version
copying build/lib.linux-x86_64-3.10/cobs/__init__.py -> build/bdist.linux-x86_64/wheel/cobs
creating build/bdist.linux-x86_64/wheel/cobs/cobsr
copying build/lib.linux-x86_64-3.10/cobs/cobsr/__init__.py -> build/bdist.linux-x86_64/wheel/cobs/cobsr
copying build/lib.linux-x86_64-3.10/cobs/cobsr/_cobsr_ext.cpython-310-x86_64-linux-gnu.so -> build/bdist.linux-x86_64/wheel/cobs/cobsr
copying build/lib.linux-x86_64-3.10/cobs/cobsr/_cobsr_py.py -> build/bdist.linux-x86_64/wheel/cobs/cobsr
copying build/lib.linux-x86_64-3.10/cobs/cobsr/test.py -> build/bdist.linux-x86_64/wheel/cobs/cobsr
running install_egg_info
running egg_info
creating UNKNOWN.egg-info
writing UNKNOWN.egg-info/PKG-INFO
writing dependency_links to UNKNOWN.egg-info/dependency_links.txt
writing top-level names to UNKNOWN.egg-info/top_level.txt
writing manifest file 'UNKNOWN.egg-info/SOURCES.txt'
reading manifest file 'UNKNOWN.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE.txt'
writing manifest file 'UNKNOWN.egg-info/SOURCES.txt'
Copying UNKNOWN.egg-info to build/bdist.linux-x86_64/wheel/UNKNOWN-0.0.0.egg-info
running install_scripts
adding license file "LICENSE.txt" (matched pattern "LICEN[CS]E*")
creating build/bdist.linux-x86_64/wheel/UNKNOWN-0.0.0.dist-info/WHEEL
creating 'dist/UNKNOWN-0.0.0-cp310-cp310-linux_x86_64.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'cobs/__init__.py'
adding 'cobs/_version/__init__.py'
adding 'cobs/cobs/__init__.py'
adding 'cobs/cobs/_cobs_ext.cpython-310-x86_64-linux-gnu.so'
adding 'cobs/cobs/_cobs_py.py'
adding 'cobs/cobs/test.py'
adding 'cobs/cobsr/__init__.py'
adding 'cobs/cobsr/_cobsr_ext.cpython-310-x86_64-linux-gnu.so'
adding 'cobs/cobsr/_cobsr_py.py'
adding 'cobs/cobsr/test.py'
adding 'UNKNOWN-0.0.0.dist-info/LICENSE.txt'
adding 'UNKNOWN-0.0.0.dist-info/METADATA'
adding 'UNKNOWN-0.0.0.dist-info/WHEEL'
adding 'UNKNOWN-0.0.0.dist-info/top_level.txt'
adding 'UNKNOWN-0.0.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
```
</details>


<details>
<summary>Install log for fixed branch</summary>

```sh
altracer@HP-15s-fq3025ur ~/g/c/cobs-python (fix/wheel)> python3 setup.py bdist_wheel
running bdist_wheel
running build
running build_py
creating build
creating build/lib.linux-x86_64-3.10
creating build/lib.linux-x86_64-3.10/cobs
copying src/cobs/__init__.py -> build/lib.linux-x86_64-3.10/cobs
creating build/lib.linux-x86_64-3.10/cobs/cobs
copying src/cobs/cobs/_cobs_py.py -> build/lib.linux-x86_64-3.10/cobs/cobs
copying src/cobs/cobs/__init__.py -> build/lib.linux-x86_64-3.10/cobs/cobs
copying src/cobs/cobs/test.py -> build/lib.linux-x86_64-3.10/cobs/cobs
creating build/lib.linux-x86_64-3.10/cobs/cobsr
copying src/cobs/cobsr/__init__.py -> build/lib.linux-x86_64-3.10/cobs/cobsr
copying src/cobs/cobsr/_cobsr_py.py -> build/lib.linux-x86_64-3.10/cobs/cobsr
copying src/cobs/cobsr/test.py -> build/lib.linux-x86_64-3.10/cobs/cobsr
creating build/lib.linux-x86_64-3.10/cobs/_version
copying src/cobs/_version/__init__.py -> build/lib.linux-x86_64-3.10/cobs/_version
running build_ext
building 'cobs.cobs._cobs_ext' extension
creating build/temp.linux-x86_64-3.10
creating build/temp.linux-x86_64-3.10/src
creating build/temp.linux-x86_64-3.10/src/ext
x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_F
ORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.10 -c src/ext/_cobs_ext.c -o build/temp.linux-x86_64-3.10/src/ext/_cobs_ext.o
x86_64-linux-gnu-gcc -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -fwrapv -O2 -Wl,-Bsymbolic-functions -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 bui
ld/temp.linux-x86_64-3.10/src/ext/_cobs_ext.o -o build/lib.linux-x86_64-3.10/cobs/cobs/_cobs_ext.cpython-310-x86_64-linux-gnu.so
building 'cobs.cobsr._cobsr_ext' extension
x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_F
ORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.10 -c src/ext/_cobsr_ext.c -o build/temp.linux-x86_64-3.10/src/ext/_cobsr_ext.o
x86_64-linux-gnu-gcc -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -fwrapv -O2 -Wl,-Bsymbolic-functions -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 bui
ld/temp.linux-x86_64-3.10/src/ext/_cobsr_ext.o -o build/lib.linux-x86_64-3.10/cobs/cobsr/_cobsr_ext.cpython-310-x86_64-linux-gnu.so
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/cobs
creating build/bdist.linux-x86_64/wheel/cobs/cobs
copying build/lib.linux-x86_64-3.10/cobs/cobs/_cobs_py.py -> build/bdist.linux-x86_64/wheel/cobs/cobs
copying build/lib.linux-x86_64-3.10/cobs/cobs/__init__.py -> build/bdist.linux-x86_64/wheel/cobs/cobs
copying build/lib.linux-x86_64-3.10/cobs/cobs/_cobs_ext.cpython-310-x86_64-linux-gnu.so -> build/bdist.linux-x86_64/wheel/cobs/cobs
copying build/lib.linux-x86_64-3.10/cobs/cobs/test.py -> build/bdist.linux-x86_64/wheel/cobs/cobs
creating build/bdist.linux-x86_64/wheel/cobs/_version
copying build/lib.linux-x86_64-3.10/cobs/_version/__init__.py -> build/bdist.linux-x86_64/wheel/cobs/_version
copying build/lib.linux-x86_64-3.10/cobs/__init__.py -> build/bdist.linux-x86_64/wheel/cobs
creating build/bdist.linux-x86_64/wheel/cobs/cobsr
copying build/lib.linux-x86_64-3.10/cobs/cobsr/__init__.py -> build/bdist.linux-x86_64/wheel/cobs/cobsr
copying build/lib.linux-x86_64-3.10/cobs/cobsr/_cobsr_ext.cpython-310-x86_64-linux-gnu.so -> build/bdist.linux-x86_64/wheel/cobs/cobsr
copying build/lib.linux-x86_64-3.10/cobs/cobsr/_cobsr_py.py -> build/bdist.linux-x86_64/wheel/cobs/cobsr
copying build/lib.linux-x86_64-3.10/cobs/cobsr/test.py -> build/bdist.linux-x86_64/wheel/cobs/cobsr
running install_egg_info
running egg_info
creating cobs.egg-info
writing cobs.egg-info/PKG-INFO
writing dependency_links to cobs.egg-info/dependency_links.txt
writing top-level names to cobs.egg-info/top_level.txt
writing manifest file 'cobs.egg-info/SOURCES.txt'
reading manifest file 'cobs.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE.txt'
writing manifest file 'cobs.egg-info/SOURCES.txt'
Copying cobs.egg-info to build/bdist.linux-x86_64/wheel/cobs-1.2.1.egg-info
running install_scripts
adding license file "LICENSE.txt" (matched pattern "LICEN[CS]E*")
creating build/bdist.linux-x86_64/wheel/cobs-1.2.1.dist-info/WHEEL
creating 'dist/cobs-1.2.1-cp310-cp310-linux_x86_64.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'cobs/__init__.py'
adding 'cobs/_version/__init__.py'
adding 'cobs/cobs/__init__.py'
adding 'cobs/cobs/_cobs_ext.cpython-310-x86_64-linux-gnu.so'
adding 'cobs/cobs/_cobs_py.py'
adding 'cobs/cobs/test.py'
adding 'cobs/cobsr/__init__.py'
adding 'cobs/cobsr/_cobsr_ext.cpython-310-x86_64-linux-gnu.so'
adding 'cobs/cobsr/_cobsr_py.py'
adding 'cobs/cobsr/test.py'
adding 'cobs-1.2.1.dist-info/LICENSE.txt'
adding 'cobs-1.2.1.dist-info/METADATA'
adding 'cobs-1.2.1.dist-info/WHEEL'
adding 'cobs-1.2.1.dist-info/top_level.txt'
adding 'cobs-1.2.1.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
```
</details>

Tested on Linux Mint Cinnamon 21.3 x86_64 (like Ubuntu 22.04 LTS jammy) with stock python3.10 to produce a `cobs-1.2.1-cp310-cp310-linux_x86_64.whl` and increase performance from
> encoding: 0.008716974987931236 GB/s
> decoding: 0.03147893895000613 GB/s

to
> encoding: 0.6623471130306869 GB/s
> decoding: 1.2416340383593132 GB/s

P.S. Redid the experiment on Raspberry Pi 3B running Aarch64 Debian 11 bullseye, and `python3.9 setup.py bdist_wheel` also does the UNKNOWN thing, but `pip3 install --user cobs` downloads and compiles a wheel `cobs-1.2.1-cp39-cp39-linux_aarch64.whl` correctly. Maybe I'm using it wrong. With this fix, local setup.py works correctly.